### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,11 +55,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
         make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What

Pin every third-party GitHub Action referenced in this repo (workflows + composite actions) to a full 40-character commit SHA, with the original version tag preserved as a trailing comment (e.g. `actions/checkout@<sha> # v6.0.2`).

## Why

Per [GitHub's security hardening guide for Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), third-party actions should be pinned to a full commit SHA. Version tags and branch refs are mutable and a compromised tag (as happened with `tj-actions/changed-files` in March 2025) can give an attacker arbitrary code execution with our secrets.

## How

- Ran [`pinact`](https://github.com/suzuki-shunsuke/pinact) over `.github/workflows/` and `.github/actions/`.
- Manually pinned refs pinact could not resolve (e.g. `sigstore/cosign-installer@main`, `superfly/flyctl-actions/setup-flyctl@master`) to the current HEAD of their respective branches.

## Tests

No source code changes. CI on this PR exercises the pinned workflows end-to-end.

---

Part of a wider rollout across active repos.